### PR TITLE
Add notice of repository archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This repository contains a sample GitHub App built with [Probot](https://github.com/probot/probot) that demonstrates how to monitor and respond to security alert events. The application automatically re-opens any security alert which is closed by someone that is not part of a specific team. It responds to alerts from code scanning, secret scanning, and Dependabot.
 
+> [!CAUTION]
+> This repository is no longer supported or updated, and the repository has been archived. If you wish to continue to
+> develop this code yourself, we recommend you fork it.
+> GitHub [announced](https://github.blog/changelog/2025-03-05-delegated-alert-dismissal-for-code-scanning-and-secret-scanning-now-available-in-public-preview/)
+> a native feature that provides similar functionality, and we recommend adopting that if you need
+> to support delegated alert dismissal.
+
 ## Requirements
 
 The repository contains a [development container](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers) that supports Visual Studio Code and GitHub Codespaces. This container includes all of the required dependencies. The application is written in TypeScript, runs on Node.js 22, and uses Yarn for package management. Opening the project in a development container will automatically install the required components and configure VS Code.   
@@ -21,9 +28,9 @@ The current project maintainers can be found in [CODEOWNERS](./.github/CODEOWNER
 
 ## Node versions
 
-The application and its development environment are currently tested and maintained using the upcoming LTS, Node 22.
+The application and its development environment are currently tested and maintained using Node 22.
 
-Because Node 18 is no longer in Active Support, it is not recommended and is no longer supported. The original version of this project. That said, the code produced by `yarn run build` and `yarn run build:container` in `packages/server` *should* work when run using Node 18 and Node 20. Your mileage may vary.
+Because Node 18 is no longer in Active Support, it is not recommended and is no longer supported. The code produced by `yarn run build` and `yarn run build:container` in `packages/server` *should* work when run using Node 18 and Node 20. Your mileage may vary.
 
 ## Setup and Local Development
 
@@ -175,7 +182,8 @@ The following commands can be used for configuration and deployment.
 A debug configuration is provided for launching the AWS Lambda locally. The configurtion currently does not fully support debugging.
 
 > [!IMPORTANT]
-> GitHub webhooks expect a response within 10 seconds. Be sure to validate that your Lambda configuration will allow the function to respond within the required timeframe.
+> GitHub webhooks expect a response within 10 seconds. Be sure to validate that your Lambda configuration will
+> allow the function to respond within the required timeframe.
 
 #### Azure Functions
 
@@ -184,7 +192,9 @@ The `packages/azure` folder contains the code and configuration for deploying th
 A debug configuration is provided for launching the Azure Function locally.
 
 > [!IMPORTANT]
-> GitHub webhooks expect a response within 10 seconds. This may require a Premium Azure Function plan to ensure the Function's [cold start behavior](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#cold-start-behavior) will allow it to respond within the required timeframe.
+> GitHub webhooks expect a response within 10 seconds. This may require a Premium Azure Function
+> plan to ensure the Function's [cold start behavior](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#cold-start-behavior)
+> will allow it to respond within the required timeframe.
 
 ### Installation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,31 +1,7 @@
-Thanks for helping make GitHub safe for everyone.
-
 # Security
 
 GitHub takes the security of our software products and services seriously, including all of the open source code repositories managed through our GitHub organizations, such as [GitHub](https://github.com/GitHub).
 
-Even though [open source repositories are outside of the scope of our bug bounty program](https://bounty.github.com/index.html#scope) and therefore not eligible for bounty rewards, we will ensure that your finding gets passed along to the appropriate maintainers for remediation. 
+[Open source repositories are outside of the scope of our bug bounty program](https://bounty.github.com/index.html#scope) and therefore not eligible for bounty rewards.
 
-## Reporting Security Issues
-
-If you believe you have found a security vulnerability in any GitHub-owned repository, please report it to us through coordinated disclosure.
-
-**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
-
-Instead, please send an email to opensource-security[@]github.com.
-
-Please include as much of the information listed below as you can to help us better understand and resolve the issue:
-
-  * The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
-
-This information will help us triage your report more quickly.
-
-## Policy
-
-See [GitHub's Safe Harbor Policy](https://docs.github.com/en/github/site-policy/github-bug-bounty-program-legal-safe-harbor#1-safe-harbor-terms)
+This repository is archived and deprecated. It is no longer being updated, supported, or maintained by GitHub staff.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,13 +1,3 @@
 # Support
 
-## How to file issues and get help
-
-This project uses GitHub issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your bug or feature request as a new issue.
-
-For help or questions about using this project, please create an issue.
-
-Probot Security Alert Watcher is not actively developed but is maintained by GitHub staff **AND THE COMMUNITY**. We will do our best to respond to support and community questions in a timely manner.
-
-## GitHub Support Policy
-
-Support for this project is limited to the resources listed above.
+The Probot Security Alert Watcher is archived and deprecated. It is no longer supported or maintained by GitHub staff, and we will not respond to support or community questions. Feel free to fork.


### PR DESCRIPTION
This repository is being archived and will no longer being maintained. This pull request makes it explicit in the `README.md`, `SUPPORT.md`, and `SECURITY.md` files.

GitHub now [provides the functionality](https://github.blog/changelog/2025-03-05-delegated-alert-dismissal-for-code-scanning-and-secret-scanning-now-available-in-public-preview/) that was available in this sample application, so that is the recommended direction for customers.

/cc @tspascoal @NickLiffen 